### PR TITLE
Fix random selection range

### DIFF
--- a/src/Turdle.Tests/ExtensionsTests.cs
+++ b/src/Turdle.Tests/ExtensionsTests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using Turdle.Utils;
+using Xunit;
+
+namespace Turdle.Tests;
+
+public class ExtensionsTests
+{
+    [Fact]
+    public void PickRandom_SingleElementList_ReturnsElement()
+    {
+        var list = new List<int> { 42 };
+        var result = list.PickRandom();
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void PickRandom_CanSelectLastElement()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        var foundLast = false;
+        for (var i = 0; i < 100 && !foundLast; i++)
+        {
+            foundLast = list.PickRandom() == 3;
+        }
+        Assert.True(foundLast);
+    }
+}

--- a/src/Turdle.Utils/Extensions.cs
+++ b/src/Turdle.Utils/Extensions.cs
@@ -6,7 +6,7 @@ public static class Extensions
     
     public static T PickRandom<T>(this IList<T> set)
     {
-        return set[Random.Next(0, set.Count - 1)];
+        return set[Random.Next(0, set.Count)];
     }
 
     public static string GetOrdinal(this int value, bool includeNumber = false)


### PR DESCRIPTION
## Summary
- ensure PickRandom includes all list elements
- add unit tests for PickRandom including single-element lists

## Testing
- `dotnet test src/Turdle.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844a8ba3b7c832a960fa1b99bac6af6