### PR TITLE
Fix GitHub workflow deprecation

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,7 +38,7 @@ jobs:
       working-directory: ./src
       run: dotnet test --verbosity normal
     - name: Publish Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: turdle
         path: ~/build/turdle


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` to v4 in workflow

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: command not found)*
- `npm test --prefix src/Turdle/ClientApp` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844ad4bec1c832aad87df279a407124