### PR TITLE
Add staging environment indicator

### DIFF
--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.css
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.css
@@ -21,3 +21,11 @@ html {
 .box-shadow {
   box-shadow: 0 .25rem .75rem rgba(0, 0, 0, .05);
 }
+
+.staging-banner {
+  background-color: #ff6600;
+  color: white;
+  text-align: center;
+  font-weight: bold;
+  padding: 0.25rem;
+}

--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.html
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.html
@@ -1,4 +1,7 @@
 <header>
+  <div class="staging-banner" *ngIf="environmentName === 'Staging'">
+    STAGING ENVIRONMENT
+  </div>
   <nav
     class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3"
   >

--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.ts
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.ts
@@ -1,14 +1,24 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { environment } from '../../environments/environment';
+import { EnvironmentService } from '../services/environment.service';
 
 @Component({
   selector: 'app-nav-menu',
   templateUrl: './nav-menu.component.html',
   styleUrls: ['./nav-menu.component.css']
 })
-export class NavMenuComponent {
+export class NavMenuComponent implements OnInit {
   isExpanded = false;
   public environment = environment;
+  public environmentName: string | null = null;
+
+  constructor(private environmentService: EnvironmentService) {
+  }
+
+  ngOnInit(): void {
+    this.environmentService.environmentName$.subscribe(name => this.environmentName = name || null);
+    this.environmentService.loadEnvironment();
+  }
 
   collapse() {
     this.isExpanded = false;

--- a/src/Turdle/ClientApp/src/app/services/environment.service.ts
+++ b/src/Turdle/ClientApp/src/app/services/environment.service.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EnvironmentService {
+  private environmentNameSubject = new BehaviorSubject<string | null>(null);
+  public environmentName$ = this.environmentNameSubject.asObservable();
+
+  constructor(private http: HttpClient, @Inject('BASE_URL') private baseUrl: string) { }
+
+  public loadEnvironment(): void {
+    this.http.get(this.baseUrl + 'GetEnvironmentName', { responseType: 'text' })
+      .subscribe(name => this.environmentNameSubject.next(name));
+  }
+}

--- a/src/Turdle/Controllers/EnvironmentController.cs
+++ b/src/Turdle/Controllers/EnvironmentController.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Turdle.Controllers;
+
+[ApiController]
+public class EnvironmentController : ControllerBase
+{
+    private readonly IConfiguration _configuration;
+
+    public EnvironmentController(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    [HttpGet]
+    [Route("GetEnvironmentName")]
+    public string GetEnvironmentName()
+    {
+        return _configuration["EnvironmentName"] ?? "Production";
+    }
+}

--- a/src/Turdle/appsettings.Staging.json
+++ b/src/Turdle/appsettings.Staging.json
@@ -1,0 +1,3 @@
+{
+  "EnvironmentName": "Staging"
+}

--- a/src/Turdle/appsettings.json
+++ b/src/Turdle/appsettings.json
@@ -9,5 +9,6 @@
   "ChatGpt": {
     "ApiKey": ""
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "EnvironmentName": "Production"
 }


### PR DESCRIPTION
## Summary
- add environment controller to expose environment name
- show "STAGING ENVIRONMENT" banner in the nav when appsettings sets EnvironmentName to Staging
- add an Angular service and component updates to fetch environment name
- add appsettings for staging configuration

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68472a29d9b0832a9dcb4c0ebb2d30be