### PR TITLE
Improve lobby chat realism

### DIFF
--- a/src/Turdle/ClientApp/src/app/game/game.component.css
+++ b/src/Turdle/ClientApp/src/app/game/game.component.css
@@ -36,3 +36,8 @@ div.chat-messages {
   display: flex;
   flex-direction: column-reverse;
 }
+
+.typing-indicator {
+  font-style: italic;
+  color: gray;
+}

--- a/src/Turdle/ClientApp/src/app/game/game.component.html
+++ b/src/Turdle/ClientApp/src/app/game/game.component.html
@@ -77,8 +77,11 @@
               </tr>
             </tbody>
           </table>
+          <div *ngIf="typingPlayers.length > 0" class="typing-indicator">
+            {{ typingPlayers.join(', ') }} typing...
+          </div>
         </div>
-        <input type="text" id="chatInput" name="chatInput" class="form-control" [(ngModel)]="chatInput" (keyup.enter)="sendChat()" #chatInputField />
+        <input type="text" id="chatInput" name="chatInput" class="form-control" [(ngModel)]="chatInput" (keyup.enter)="sendChat()" (input)="chatTyping()" #chatInputField />
       </div>
       <div *ngIf="roundState.status == 'Ready'">
         <!--        <button class="btn btn-success" (click)="startGame()">Start!</button>-->

--- a/src/Turdle/ClientApp/src/app/game/game.component.ts
+++ b/src/Turdle/ClientApp/src/app/game/game.component.ts
@@ -142,6 +142,13 @@ export class GameComponent {
     this.chatInput = '';
     await this.gameService.sendChatMessage(message);
   }
+
+  public chatTyping(): void {
+    if (this.chatInput && this.chatInput.length > 0)
+      this.gameService.notifyTyping();
+    else
+      this.gameService.notifyStopTyping();
+  }
   public async prepopulateChat(alias: string): Promise<void> {
     this.chatInput = '@' + alias + ' ';
     this.chatInputField.nativeElement.focus();
@@ -214,6 +221,9 @@ export class GameComponent {
   }
   get chatMessages(): ChatMessage[] {
     return this.gameService.chatMessages;
+  }
+  get typingPlayers(): string[] {
+    return this.gameService.typingAliases;
   }
 
   // UTILS

--- a/src/Turdle/Hubs/GameHub.cs
+++ b/src/Turdle/Hubs/GameHub.cs
@@ -213,8 +213,27 @@ public class GameHub : Hub
     {
         using (LogContext.Create(_logger, Context.ConnectionId, "SendChat"))
         {
+            var room = _roomManager.GetRoom(roomCode);
+            await room.SendChat(Context.ConnectionId, message);
+            await room.NotifyStoppedTyping(Context.ConnectionId);
+        }
+    }
+
+    public async Task Typing(string roomCode)
+    {
+        using (LogContext.Create(_logger, Context.ConnectionId, "Typing"))
+        {
             await _roomManager.GetRoom(roomCode)
-                .SendChat(Context.ConnectionId, message);
+                .NotifyTyping(Context.ConnectionId);
+        }
+    }
+
+    public async Task StopTyping(string roomCode)
+    {
+        using (LogContext.Create(_logger, Context.ConnectionId, "StopTyping"))
+        {
+            await _roomManager.GetRoom(roomCode)
+                .NotifyStoppedTyping(Context.ConnectionId);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add new Typing API on GameHub and notify clients
- delay bot chat messages and broadcast typing status
- handle PlayerTyping event on client
- show typing indicator in chat UI
- minor CSS for typing indicator
- keep typing indicator until message sent or cleared
- refactor bot chat delay to use NotifyTyping and SendChat directly

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*
- `npm test --silent` *(fails: `connect ETIMEDOUT registry.npmjs.org`)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6849995278d0832a92b0e1d1ad0c02f7