### PR TITLE
Move typing indicator below chat messages

### DIFF
--- a/src/Turdle/ClientApp/src/app/game/game.component.html
+++ b/src/Turdle/ClientApp/src/app/game/game.component.html
@@ -77,9 +77,9 @@
               </tr>
             </tbody>
           </table>
-          <div *ngIf="typingPlayers.length > 0" class="typing-indicator">
-            {{ typingPlayers.join(', ') }} typing...
-          </div>
+        </div>
+        <div *ngIf="typingPlayers.length > 0" class="typing-indicator">
+          {{ typingPlayers.join(', ') }} typing...
         </div>
         <input type="text" id="chatInput" name="chatInput" class="form-control" [(ngModel)]="chatInput" (keyup.enter)="sendChat()" (input)="chatTyping()" #chatInputField />
       </div>


### PR DESCRIPTION
## Summary
- adjust chat layout so the typing indicator appears below the message list

## Testing
- `dotnet test src/Turdle.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686054f66cc4832ab6d8385fe12ea34e