### PR TITLE
Fix version step placement

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,8 +26,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 8.0.x
-    - name: Set version
-      run: echo "VERSION=$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
     - name: Restore dependencies
       working-directory: ./src
       run: dotnet restore
@@ -44,6 +42,8 @@ jobs:
       with:
         name: turdle
         path: ~/build/turdle
+    - name: Set version
+      run: echo "VERSION=$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
     - name: Tar
       run: |
         tar -C ~/build/turdle -cvf turdle_${VERSION}.tar .


### PR DESCRIPTION
## Summary
- move `Set version` step back to run after build

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860710a22d0832aaec877b205317665