### PR TITLE
Update staging version formatting and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@
 
 The staging banner now displays a version string automatically derived from the
 modification timestamp of the API's main assembly. The version uses the format
-`vyyyy-MM-dd-HH-mm`, so it changes with every new deployment without requiring
+`v{yyyyMMdd-HHmm}`, so it changes with every new deployment without requiring
 any additional configuration.

--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.css
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.css
@@ -28,4 +28,13 @@ html {
   text-align: center;
   font-weight: 500;
   padding: 0.15rem;
+  position: relative;
+}
+
+.staging-version {
+  position: absolute;
+  right: 0.25rem;
+  font-size: 0.65rem;
+  top: 50%;
+  transform: translateY(-50%);
 }

--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.html
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.html
@@ -1,6 +1,7 @@
 <header>
   <div class="staging-banner" *ngIf="environmentName === 'Staging'">
-    STAGING ENVIRONMENT<span *ngIf="environmentVersion"> - {{ environmentVersion }}</span>
+    STAGING ENVIRONMENT
+    <span *ngIf="environmentVersion" class="staging-version">{{ environmentVersion }}</span>
   </div>
   <nav
     class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3"

--- a/src/Turdle/Controllers/EnvironmentController.cs
+++ b/src/Turdle/Controllers/EnvironmentController.cs
@@ -26,8 +26,8 @@ public class EnvironmentController : ControllerBase
         var name = _configuration["EnvironmentName"] ?? "Production";
 
         var assembly = typeof(EnvironmentController).Assembly;
-        var version = System.IO.File.GetLastWriteTimeUtc(assembly.Location)
-            .ToString("'v'yyyy-MM-dd-HH-mm");
+        var timestamp = System.IO.File.GetLastWriteTimeUtc(assembly.Location);
+        var version = $"v{{{timestamp:yyyyMMdd-HHmm}}}";
 
         return new Turdle.ViewModel.EnvironmentInfo(name, version);
     }


### PR DESCRIPTION
## Summary
- tweak the version string format in `EnvironmentController`
- move staging version text in nav menu to the right and shrink it
- document the new version format

## Testing
- `dotnet test src/Turdle.sln` *(fails: command not found)*
- `npm test` *(fails: `npm` couldn't find package.json)*


------
https://chatgpt.com/codex/tasks/task_b_6860742032b8832ab649469ab00e3577