### PR TITLE
Make home controls bigger

### DIFF
--- a/src/Turdle/ClientApp/src/app/home/home.component.css
+++ b/src/Turdle/ClientApp/src/app/home/home.component.css
@@ -1,0 +1,17 @@
+
+.massive-button {
+  font-size: 3rem;
+  padding: 1.25rem 2.5rem;
+  border-radius: 1rem;
+  background: linear-gradient(45deg, #ff66cc, #33ccff);
+  color: #fff;
+  border: none;
+}
+
+
+.massive-input {
+  font-size: 2.5rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 2px solid #33ccff;
+}

--- a/src/Turdle/ClientApp/src/app/home/home.component.html
+++ b/src/Turdle/ClientApp/src/app/home/home.component.html
@@ -15,15 +15,15 @@
 <!--  </form>-->
   <div class="row mb-3">
     <div class="col text-center">
-      <button class="btn btn-primary btn-lg" (click)="createRoom()">Create New Room</button>
+      <button class="btn btn-primary btn-lg massive-button" (click)="createRoom()">Create New Room</button>
     </div>
   </div>
   <div class="row">
     <div class="col-md-6 offset-md-3">
       <form [formGroup]="joinForm" (ngSubmit)="joinRoom()">
         <div class="input-group">
-          <input type="text" class="form-control" placeholder="Enter room code" formControlName="roomCode" required>
-          <button class="btn btn-success" type="submit" [disabled]="!joinForm.valid">Join Room</button>
+          <input type="text" class="form-control massive-input" placeholder="Enter room code" formControlName="roomCode" required>
+          <button class="btn btn-success btn-lg massive-button" type="submit" [disabled]="!joinForm.valid">Join Room</button>
         </div>
       </form>
     </div>

--- a/src/Turdle/ClientApp/src/app/home/home.component.ts
+++ b/src/Turdle/ClientApp/src/app/home/home.component.ts
@@ -7,6 +7,7 @@ import { HomeService } from '../services/home.service';
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
+  styleUrls: ['./home.component.css']
 })
 export class HomeComponent {
 


### PR DESCRIPTION
## Summary
- enlarge the 'Create New Room' and 'Join Room' buttons using a `.massive-button` class
- size up the room code input field with `.massive-input`

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test -- --watch=false` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_b_6861a5e912b8832a8ff32457256204ca