### PR TITLE
Split dotnet workflow

### DIFF
--- a/.github/workflows/dotnet-pr.yml
+++ b/.github/workflows/dotnet-pr.yml
@@ -4,7 +4,7 @@
 name: .NET build
 
 on:
-  push:
+  pull_request:
     branches: [ "main" ]
 
 jobs:
@@ -45,7 +45,7 @@ jobs:
     - name: Set branch
       run: echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
       env:
-        BRANCH: ${{ github.ref_name }}
+        BRANCH: ${{ github.head_ref }}
     - name: Tar
       run: |
         tar -C ~/build/turdle -cvf turdle_${VERSION}.tar .

--- a/.github/workflows/dotnet-pr.yml
+++ b/.github/workflows/dotnet-pr.yml
@@ -43,10 +43,7 @@ jobs:
     - name: Set version
       run: echo "VERSION=$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
     - name: Set branch
-      run: |
-        BRANCH="${{ github.head_ref }}"
-        BRANCH="${BRANCH##*/}"
-        echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+      run: echo "BRANCH=pr-${{ github.event.number }}" >> $GITHUB_ENV
     - name: Tar
       run: |
         tar -C ~/build/turdle -cvf turdle_${VERSION}.tar .

--- a/.github/workflows/dotnet-pr.yml
+++ b/.github/workflows/dotnet-pr.yml
@@ -43,9 +43,10 @@ jobs:
     - name: Set version
       run: echo "VERSION=$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
     - name: Set branch
-      run: echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-      env:
-        BRANCH: ${{ github.head_ref }}
+      run: |
+        BRANCH="${{ github.head_ref }}"
+        BRANCH="${BRANCH##*/}"
+        echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
     - name: Tar
       run: |
         tar -C ~/build/turdle -cvf turdle_${VERSION}.tar .

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -43,9 +43,10 @@ jobs:
     - name: Set version
       run: echo "VERSION=$(date +'%Y%m%d%H%M')" >> $GITHUB_ENV
     - name: Set branch
-      run: echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
-      env:
-        BRANCH: ${{ github.ref_name }}
+      run: |
+        BRANCH="${{ github.ref_name }}"
+        BRANCH="${BRANCH##*/}"
+        echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
     - name: Tar
       run: |
         tar -C ~/build/turdle -cvf turdle_${VERSION}.tar .


### PR DESCRIPTION
## Summary
- split dotnet workflow into push and PR versions
- embed branch name in release path
- adjust release directory naming to append branch to version

## Testing
- `dotnet test src/Turdle.Tests/Turdle.Tests.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861a8a29934832a89a0e2817372ecb1