### PR TITLE
Update staging banner to be a link

### DIFF
--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.css
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.css
@@ -31,6 +31,11 @@ html {
   position: relative;
 }
 
+.staging-banner a {
+  color: inherit;
+  text-decoration: none;
+}
+
 .staging-version {
   position: absolute;
   right: 0.25rem;

--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.html
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.html
@@ -1,6 +1,6 @@
 <header>
   <div class="staging-banner" *ngIf="environmentName === 'Staging'">
-    STAGING ENVIRONMENT
+    <a href="/" class="staging-link">STAGING ENVIRONMENT</a>
     <span *ngIf="environmentVersion" class="staging-version">{{ environmentVersion }}</span>
   </div>
   <nav


### PR DESCRIPTION
## Summary
- make the staging banner text a normal hyperlink to `/`
- keep banner styling when used as a link

## Testing
- `dotnet test src/Turdle.sln` *(fails: `dotnet` not found)*
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862b58aa2ec832a85d8fe3f6b8e1a7c