### PR TITLE
Implement SignalR auto reconnect

### DIFF
--- a/src/Turdle/ClientApp/src/app/services/admin.service.ts
+++ b/src/Turdle/ClientApp/src/app/services/admin.service.ts
@@ -22,12 +22,11 @@ export class AdminService {
     this.hubConnection = new signalR.HubConnectionBuilder()
       .withUrl(this.baseUrl + 'adminHub')
       .build();
-    try {
-      await this.hubConnection.start();
-    } catch (e) {
-      console.log('Error while starting connection: ' + e);
-      return;
-    }
+    this.hubConnection.onclose(() => {
+      setTimeout(() => this.startConnection(), 5000);
+    });
+
+    await this.startConnection();
 
     console.log('Admin hub connection started');
     this.hubConnection?.on('Ping', (data) => {
@@ -116,6 +115,16 @@ export class AdminService {
       await this.hubConnection.invoke('UpdateMaxGuesses', maxGuesses);
     } catch (e) {
       console.log('Error updating max guesses: ' + e);
+    }
+  }
+
+  private async startConnection(): Promise<void> {
+    if (!this.hubConnection) return;
+    try {
+      await this.hubConnection.start();
+    } catch (e) {
+      console.log('Error while starting connection: ' + e);
+      setTimeout(() => this.startConnection(), 5000);
     }
   }
 


### PR DESCRIPTION
## Summary
- add reconnection logic in HomeService
- add reconnection logic in AdminService
- add reconnection logic in GameService

## Testing
- `dotnet test src/Turdle.sln --no-build` *(fails: dotnet not found)*
- `npm test` *(fails: ng not found and network restricted)*

------
https://chatgpt.com/codex/tasks/task_b_6862b91d649c832a831118ba8fc703d2