### PR TITLE
Add OpenAI image client

### DIFF
--- a/src/ChatGpt/ImageGenerationClient.cs
+++ b/src/ChatGpt/ImageGenerationClient.cs
@@ -31,8 +31,7 @@ namespace ChatGpt
 
         public async Task<string?> GenerateImage(
             string prompt,
-            int n = 1,
-            ImageSize size = ImageSize.Square,
+            ImageSize size = ImageSize.DallE2Medium,
             ImageQuality quality = ImageQuality.Auto,
             string model = Model,
             bool transparentBackground = true)
@@ -40,15 +39,17 @@ namespace ChatGpt
             var request = new ImageGenerationRequest(
                 model,
                 prompt,
-                n,
-                size.ToApiString(),
-                quality.ToApiString(),
-                transparentBackground);
+                1,
+                size.ToApiString()
+                //"standard" // quality.ToApiString(),
+                //transparentBackground,
+                //"low"
+                );
             _logger.LogInformation("Calling OpenAI Image Generation API.");
 
             var response = await SendRequest<ImageGenerationRequest, ImageGenerationResponse>(ImageGenerationApiUri, request);
 
-            return response.data.FirstOrDefault()?.url;
+            return response.data?.FirstOrDefault()?.url;
         }
 
         private async Task<TResponse> SendRequest<TRequest, TResponse>(string url, TRequest request)
@@ -67,18 +68,23 @@ namespace ChatGpt
             string model,
             string prompt,
             int n,
-            string size,
-            string quality,
-            bool transparent);
+            string size
+            //string quality
+            //bool transparent,
+            //string moderation
+            );
         private record ImageGenerationResponse(ImageData[] data);
-        private record ImageData(string url);
+        private record ImageData(string url, string? revised_prompt);
     }
 
     public enum ImageSize
     {
-        Square,
-        Landscape,
-        Portrait,
+        DallE2Small,
+        DallE2Medium,
+        DallE2Large,
+        DallE3Square,
+        DallE3Landscape,
+        DallE3Portrait,
         Auto
     }
 
@@ -94,9 +100,12 @@ namespace ChatGpt
     {
         public static string ToApiString(this ImageSize size) => size switch
         {
-            ImageSize.Square => "1024x1024",
-            ImageSize.Landscape => "1536x1024",
-            ImageSize.Portrait => "1024x1536",
+            ImageSize.DallE2Small => "256x256",
+            ImageSize.DallE2Medium => "512x512",
+            ImageSize.DallE2Large => "1024x1024",
+            ImageSize.DallE3Square => "1024x1024",
+            ImageSize.DallE3Landscape => "1792x1024",
+            ImageSize.DallE3Portrait => "1024x1792",
             _ => "auto"
         };
 

--- a/src/ChatGpt/ImageGenerationClient.cs
+++ b/src/ChatGpt/ImageGenerationClient.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace ChatGpt
+{
+    public class ImageGenerationClient
+    {
+        private const string ImageGenerationApiUri = "https://api.openai.com/v1/images/generations";
+
+        private readonly HttpClient _httpClient;
+        private readonly ILogger<ImageGenerationClient> _logger;
+        private readonly ChatGptSettings _settings;
+
+        public ImageGenerationClient(ILogger<ImageGenerationClient> logger, IOptions<ChatGptSettings> settings)
+        {
+            _settings = settings.Value;
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {_settings.ApiKey}");
+            _logger = logger;
+        }
+
+        public ImageGenerationClient(ILogger<ImageGenerationClient> logger, IOptions<ChatGptSettings> settings, string apiKey)
+        {
+            _settings = settings.Value;
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+            _logger = logger;
+        }
+
+        private const string Model = "dall-e-3";
+
+        public async Task<string?> GenerateImage(
+            string prompt,
+            int n = 1,
+            ImageSize size = ImageSize.Square,
+            ImageQuality quality = ImageQuality.Auto,
+            string model = Model)
+        {
+            var request = new ImageGenerationRequest(
+                model,
+                prompt,
+                n,
+                size.ToApiString(),
+                quality.ToApiString(),
+                true);
+            _logger.LogInformation("Calling OpenAI Image Generation API.");
+
+            var response = await SendRequest<ImageGenerationRequest, ImageGenerationResponse>(ImageGenerationApiUri, request);
+
+            return response.data.FirstOrDefault()?.url;
+        }
+
+        private async Task<TResponse> SendRequest<TRequest, TResponse>(string url, TRequest request)
+        {
+            var json = JsonConvert.SerializeObject(request);
+            var content = new StringContent(json, System.Text.Encoding.UTF8, "application/json");
+
+            var response = await _httpClient.PostAsync(url, content);
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            var result = JsonConvert.DeserializeObject<TResponse>(responseContent);
+            return result!;
+        }
+
+        private record ImageGenerationRequest(
+            string model,
+            string prompt,
+            int n,
+            string size,
+            string quality,
+            bool transparent);
+        private record ImageGenerationResponse(ImageData[] data);
+        private record ImageData(string url);
+    }
+
+    public enum ImageSize
+    {
+        Square,
+        Landscape,
+        Portrait,
+        Auto
+    }
+
+    public enum ImageQuality
+    {
+        Low,
+        Medium,
+        High,
+        Auto
+    }
+
+    internal static class ImageEnumExtensions
+    {
+        public static string ToApiString(this ImageSize size) => size switch
+        {
+            ImageSize.Square => "1024x1024",
+            ImageSize.Landscape => "1536x1024",
+            ImageSize.Portrait => "1024x1536",
+            _ => "auto"
+        };
+
+        public static string ToApiString(this ImageQuality quality) => quality switch
+        {
+            ImageQuality.Low => "low",
+            ImageQuality.Medium => "medium",
+            ImageQuality.High => "high",
+            _ => "auto"
+        };
+    }
+}

--- a/src/ChatGpt/ImageGenerationClient.cs
+++ b/src/ChatGpt/ImageGenerationClient.cs
@@ -7,6 +7,7 @@ namespace ChatGpt
     public class ImageGenerationClient
     {
         private const string ImageGenerationApiUri = "https://api.openai.com/v1/images/generations";
+        private const string Model = "dall-e-2";
 
         private readonly HttpClient _httpClient;
         private readonly ILogger<ImageGenerationClient> _logger;
@@ -28,14 +29,13 @@ namespace ChatGpt
             _logger = logger;
         }
 
-        private const string Model = "dall-e-3";
-
         public async Task<string?> GenerateImage(
             string prompt,
             int n = 1,
             ImageSize size = ImageSize.Square,
             ImageQuality quality = ImageQuality.Auto,
-            string model = Model)
+            string model = Model,
+            bool transparentBackground = true)
         {
             var request = new ImageGenerationRequest(
                 model,
@@ -43,7 +43,7 @@ namespace ChatGpt
                 n,
                 size.ToApiString(),
                 quality.ToApiString(),
-                true);
+                transparentBackground);
             _logger.LogInformation("Calling OpenAI Image Generation API.");
 
             var response = await SendRequest<ImageGenerationRequest, ImageGenerationResponse>(ImageGenerationApiUri, request);

--- a/src/Turdle.Tests/Sandbox.cs
+++ b/src/Turdle.Tests/Sandbox.cs
@@ -30,6 +30,16 @@ namespace Turdle.Tests
         }
 
         [Fact(Skip = "Manual test")]
+        public async Task ImageTest()
+        {
+            var personality = "homer simpson";
+            var prompt = $"Generate a cartoon avatar of {personality}. Make them look pretentiously smart, " +
+                    "like they're trying to look smarter than they are. ";
+                    //"Make the background generic, lexical, and floral";
+            var imageUrl = await _imageGenerationClient.GenerateImage(prompt, ImageSize.DallE2Large);
+        }
+
+        [Fact(Skip = "Manual test")]
         public async Task PromptTest()
         {
             var personality = "homer simpson";

--- a/src/Turdle.Tests/Sandbox.cs
+++ b/src/Turdle.Tests/Sandbox.cs
@@ -16,11 +16,17 @@ namespace Turdle.Tests
     {
         private readonly ChatGptClient _chatGptClient;
         private readonly WordService _wordService;
+        private readonly ImageGenerationClient _imageGenerationClient;
 
         public Sandbox()
         {
-            _chatGptClient = new ChatGptClient(Mock.Of<ILogger<ChatGptClient>>(), Mock.Of<IOptions<ChatGptSettings>>());
+            var optionsMock = new Mock<IOptions<ChatGptSettings>>();
+            optionsMock.Setup(o => o.Value).Returns(new ChatGptSettings
+            {
+            });
+            _chatGptClient = new ChatGptClient(Mock.Of<ILogger<ChatGptClient>>(), optionsMock.Object);
             _wordService = new WordService();
+            _imageGenerationClient = new ImageGenerationClient(Mock.Of<ILogger<ImageGenerationClient>>(), optionsMock.Object);
         }
 
         [Fact(Skip = "Manual test")]


### PR DESCRIPTION
## Summary
- add `ImageGenerationClient` to call OpenAI's image generation endpoint
- add enums to select image size and quality
- deserialize HTTP responses in a generic helper
- fix API parameters and add model support

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_b_6862bcab9778832ab3fd43b2e94cb7d1