### PR TITLE
Add background avatar generation

### DIFF
--- a/src/ChatGpt/PersonalityAvatarService.cs
+++ b/src/ChatGpt/PersonalityAvatarService.cs
@@ -13,7 +13,7 @@ namespace ChatGpt
         {
             _imageClient = imageClient;
             _logger = logger;
-            _cacheDir = cacheDirectory ?? Path.Combine(AppContext.BaseDirectory, "avatar-cache");
+            _cacheDir = cacheDirectory ?? Path.Combine(AppContext.BaseDirectory, "wwwroot", "avatar-cache");
             Directory.CreateDirectory(_cacheDir);
         }
 

--- a/src/Turdle/Models/GameRoundState.cs
+++ b/src/Turdle/Models/GameRoundState.cs
@@ -256,21 +256,23 @@ public class InternalRoundState : IRoundState<Player, Board, Board.Row, Board.Ti
         return board;
     }
 
-    public Player RegisterPlayer(string alias, string connectionId, string ipAddress)
+    public Player RegisterPlayer(string alias, string connectionId, string ipAddress, string? avatarPath = null)
     {
         var player = _players.SingleOrDefault(x => x.Alias == alias);
         if (player != null)
         {
             if (player.IsConnected && player.IpAddress != ipAddress)
                 throw new AliasAlreadyTakenException(alias);
-            
+
             player.ConnectionId = connectionId;
             player.IpAddress = ipAddress;
             player.IsConnected = true;
+            if (avatarPath != null)
+                player.AvatarPath = avatarPath;
         }
         else
         {
-            player = new Player(alias, connectionId, ipAddress);
+            player = new Player(alias, connectionId, ipAddress, avatarPath);
             _players.Add(player);
             Players = _players.ToArray();
             RecalculateRanking();
@@ -288,9 +290,9 @@ public class InternalRoundState : IRoundState<Player, Board, Board.Row, Board.Ti
         return player;
     }
 
-    public Player RegisterBot(IBot bot, string alias)
+    public Player RegisterBot(IBot bot, string alias, string? avatarPath = null)
     {
-        var player = new Player(alias, bot);
+        var player = new Player(alias, bot, avatarPath);
         _players.Add(player);
         Players = _players.ToArray();
         RecalculateRanking();

--- a/src/Turdle/Models/Player.cs
+++ b/src/Turdle/Models/Player.cs
@@ -17,32 +17,41 @@ public class Player : IPlayer<Board, Board.Row, Board.Tile>
     public string? IpAddress { get; set; }
     public bool IsConnected { get; set; }
     public DateTime RegisteredAt { get; set; }
+
+    public string? AvatarPath { get; set; }
     
     public bool Ready { get; set; }
     public Board? Board { get; set; }
 
-    public Player(string alias, string connectionId, string ipAddress)
+    public Player(string alias, string connectionId, string ipAddress, string? avatarPath = null)
     {
         Alias = alias;
         ConnectionId = connectionId;
         IpAddress = ipAddress;
         IsConnected = true;
         RegisteredAt = DateTime.Now;
+        AvatarPath = avatarPath;
     }
 
-    public Player(string alias, IBot bot)
+    public void SetAvatarPath(string? avatarPath)
+    {
+        AvatarPath = avatarPath;
+    }
+
+    public Player(string alias, IBot bot, string? avatarPath = null)
     {
         Alias = alias;
         Bot = bot;
         ConnectionId = $"{alias}{Guid.NewGuid()}";
         IsConnected = true;
         RegisteredAt = DateTime.Now;
+        AvatarPath = avatarPath;
     }
 
     public Player CopyForNewGame()
     {
         return Bot == null
-            ? new Player(Alias, ConnectionId, IpAddress!)
+            ? new Player(Alias, ConnectionId, IpAddress!, AvatarPath)
             {
                 Points = Points,
                 Rank = Rank,
@@ -50,7 +59,7 @@ public class Player : IPlayer<Board, Board.Row, Board.Tile>
                 IsConnected = IsConnected,
                 RegisteredAt = RegisteredAt
             }
-            : new Player(Alias, Bot)
+            : new Player(Alias, Bot, AvatarPath)
             {
                 Points = Points,
                 Rank = Rank,
@@ -72,6 +81,7 @@ public class Player : IPlayer<Board, Board.Row, Board.Tile>
             IsJointRank = IsJointRank,
             IsConnected = IsConnected,
             ConnectionId = ConnectionId,
+            AvatarPath = AvatarPath,
             Ready = Ready,
             Board = Board?.Mask()
         };
@@ -90,6 +100,7 @@ public interface IPlayer<out TBoard, out TRow, out TTile>
     bool IsJointRank { get; }
     string ConnectionId { get; }
     bool IsConnected { get; }
+    string? AvatarPath { get; }
     bool Ready { get; }
     TBoard? Board { get; }
 }
@@ -104,7 +115,9 @@ public class MaskedPlayer : IPlayer<MaskedBoard, MaskedBoard.MaskedRow, MaskedBo
     public bool IsJointRank { get; set; } = true;
     public string ConnectionId { get; set; }
     public bool IsConnected { get; set; }
-    
+
+    public string? AvatarPath { get; set; }
+
     public bool Ready { get; set; }
     public MaskedBoard? Board { get; set; }
 }

--- a/src/Turdle/Program.cs
+++ b/src/Turdle/Program.cs
@@ -45,6 +45,8 @@ builder.Services.AddSignalR()
 builder.Services.AddSingleton<RoomManager>();
 builder.Services.AddSingleton<WordService>();
 builder.Services.AddSingleton<ChatGptClient>();
+builder.Services.AddSingleton<ImageGenerationClient>();
+builder.Services.AddSingleton<PersonalityAvatarService>();
 builder.Services.AddSingleton<BotFactory>();
 builder.Services.AddSingleton<IPointService, PointService>();
 builder.Services.AddSingleton<IWordAnalysisService, WordAnalysisService>();

--- a/src/Turdle/RoomManager.cs
+++ b/src/Turdle/RoomManager.cs
@@ -4,6 +4,7 @@ using Turdle.Bots;
 using Turdle.Hubs;
 using Turdle.Models;
 using Turdle.ViewModel;
+using ChatGpt;
 
 namespace Turdle;
 
@@ -20,6 +21,7 @@ public class RoomManager
     private readonly IPointService _pointService;
     private readonly IWordAnalysisService _wordAnalyst;
     private readonly BotFactory _botFactory;
+    private readonly PersonalityAvatarService _avatarService;
 
     private readonly Board _fakeReadyBoard;
     
@@ -29,7 +31,7 @@ public class RoomManager
     private readonly ConcurrentDictionary<string, Room> _rooms = new ConcurrentDictionary<string, Room>();
 
     public RoomManager(ILogger<RoomManager> logger, IHubContext<GameHub> gameHubContext, IHubContext<AdminHub> adminHubContext, IHubContext<HomeHub> homeHubContext,
-        WordService wordService, IPointService pointService, IWordAnalysisService wordAnalyst, BotFactory botFactory)
+        WordService wordService, IPointService pointService, IWordAnalysisService wordAnalyst, BotFactory botFactory, PersonalityAvatarService avatarService)
     {
         _logger = logger;
         _gameHubContext = gameHubContext;
@@ -39,6 +41,7 @@ public class RoomManager
         _wordAnalyst = wordAnalyst;
         _homeHubContext = homeHubContext;
         _botFactory = botFactory;
+        _avatarService = avatarService;
 
         _fakeReadyBoard = new Board();
         _fakeReadyBoard.AddRow("EVERY", "START", null, null, 1, pointService);
@@ -56,7 +59,7 @@ public class RoomManager
         }
 
         var room = new Room(_gameHubContext, _adminHubContext, _wordService, _pointService, _logger, _wordAnalyst,
-            roomCode, BroadcastRooms, _botFactory);
+            roomCode, BroadcastRooms, _botFactory, _avatarService);
         _rooms.TryAdd(roomCode, room);
 
         await BroadcastRooms();

--- a/src/Turdle/Turdle.csproj
+++ b/src/Turdle/Turdle.csproj
@@ -31,6 +31,9 @@
         <Content Update="wwwroot\img\turdle3.png">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
+        <Content Include="wwwroot\avatar-cache\**">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- add `SetAvatarPath` to `Player`
- load avatars for players and bots asynchronously

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6862f6029774832a94423ec3e784d6a5