### PR TITLE
Preserve avatar cache between releases

### DIFF
--- a/.github/workflows/dotnet-pr.yml
+++ b/.github/workflows/dotnet-pr.yml
@@ -71,6 +71,10 @@ jobs:
           RELEASE_DIR=/var/www/turdle/releases/$VERSION
           mkdir -p $RELEASE_DIR
           tar -C $RELEASE_DIR -xvf $TARGET_DIR/turdle_${{ env.VERSION }}.tar
+          if [ -d /var/www/turdle/staging/wwwroot/avatar-cache ]; then
+            mkdir -p $RELEASE_DIR/wwwroot/avatar-cache
+            cp -r /var/www/turdle/staging/wwwroot/avatar-cache/* $RELEASE_DIR/wwwroot/avatar-cache/ || true
+          fi
           cp /var/www/turdle/appsettings*.json $RELEASE_DIR/
           ln -sfn $RELEASE_DIR /var/www/turdle/staging
           sudo systemctl restart kestrel-turdle-staging

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -74,6 +74,10 @@ jobs:
           RELEASE_DIR=/var/www/turdle/releases/$VERSION
           mkdir -p $RELEASE_DIR
           tar -C $RELEASE_DIR -xvf $TARGET_DIR/turdle_${{ env.VERSION }}.tar
+          if [ -d /var/www/turdle/staging/wwwroot/avatar-cache ]; then
+            mkdir -p $RELEASE_DIR/wwwroot/avatar-cache
+            cp -r /var/www/turdle/staging/wwwroot/avatar-cache/* $RELEASE_DIR/wwwroot/avatar-cache/ || true
+          fi
           cp /var/www/turdle/appsettings*.json $RELEASE_DIR/
           ln -sfn $RELEASE_DIR /var/www/turdle/staging
           sudo systemctl restart kestrel-turdle-staging


### PR DESCRIPTION
## Summary
- copy previous release avatar cache during deployment

## Testing
- `dotnet test --nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863047f82e4832a8b7cc9af8fed2d75