### PR TITLE
Add avatars to game board display

### DIFF
--- a/src/Turdle/ClientApp/src/app/game-board/game-board.component.css
+++ b/src/Turdle/ClientApp/src/app/game-board/game-board.component.css
@@ -29,6 +29,22 @@ span.solved-order {
   position: relative;
 }
 
+.board-wrapper {
+  position: relative;
+}
+
+.board-avatar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.2;
+  object-fit: cover;
+  pointer-events: none;
+  z-index: 0;
+}
+
 .time-limit-line {
   position: absolute;
   top: 50%;

--- a/src/Turdle/ClientApp/src/app/game-board/game-board.component.html
+++ b/src/Turdle/ClientApp/src/app/game-board/game-board.component.html
@@ -2,8 +2,10 @@
 <div class="row" *ngIf="board != null">
 
   <div class="col-md-12">
+    <div class="board-wrapper">
+      <img *ngIf="avatarPath" [src]="avatarPath" class="board-avatar" alt="avatar" />
 
-    <table class="table word-length-{{ wordLength }}" [ngClass]="{ 'player-board': isPlayer, 'mini-board': !isPlayer }">
+      <table class="table word-length-{{ wordLength }}" [ngClass]="{ 'player-board': isPlayer, 'mini-board': !isPlayer }">
       <tbody>
       <div class="time-limit-line" *ngIf="deadlinePct != null && board.status == 'Playing'" [ngStyle]="{'top': deadlinePct + '%'}"></div>
 
@@ -72,6 +74,7 @@
       </tr>
       </tbody>
     </table>
+    </div>
 
   </div>
 

--- a/src/Turdle/ClientApp/src/app/game-board/game-board.component.ts
+++ b/src/Turdle/ClientApp/src/app/game-board/game-board.component.ts
@@ -23,6 +23,7 @@ export class GameBoardComponent {
   @Input() currentExpectedGuessCount: number | undefined;
   @Input() nextGuessDeadline: Date | null | undefined;
   @Input() guessTimeLimitMs: number | null | undefined;
+  @Input() avatarPath: string | null | undefined;
   public secondsUntilGuessDeadline: number | null = null;
   public deadlinePct: number | null = null;
   private timerSubscription: Subscription | null = null;

--- a/src/Turdle/ClientApp/src/app/game/game.component.html
+++ b/src/Turdle/ClientApp/src/app/game/game.component.html
@@ -85,7 +85,7 @@
       </div>
       <div *ngIf="roundState.status == 'Ready'">
         <!--        <button class="btn btn-success" (click)="startGame()">Start!</button>-->
-        <game-board *ngIf="fakeReadyGameBoard != null" [board]="fakeReadyGameBoard" [currentWord]="fakeReadyGameWord" [wordLength]="5" [maxGuesses]="6"></game-board>
+        <game-board *ngIf="fakeReadyGameBoard != null" [board]="fakeReadyGameBoard" [currentWord]="fakeReadyGameWord" [wordLength]="5" [maxGuesses]="6" [avatarPath]="currentPlayer?.avatarPath"></game-board>
         <keyboard *ngIf="fakeReadyGameBoard != null" [currentBoard]="fakeReadyGameBoard" (keyPress)="clickFakeReadyKey($event)"></keyboard>
       </div>
     </div>
@@ -120,10 +120,11 @@
           </h4>
         </div>
 
-        <game-board [board]="player.board" [wordLength]="roundState.wordLength" 
+        <game-board [board]="player.board" [wordLength]="roundState.wordLength"
                 [currentExpectedGuessCount]="player.board?.currentExpectedGuessCount"
                 [nextGuessDeadline]="player.board?.nextGuessDeadline"
-                [guessTimeLimitMs]="player.board?.guessTimeLimitMs" [maxGuesses]="roundState.maxGuesses"></game-board>
+                [guessTimeLimitMs]="player.board?.guessTimeLimitMs" [maxGuesses]="roundState.maxGuesses"
+                [avatarPath]="player.avatarPath"></game-board>
 
       </div>
 
@@ -159,7 +160,8 @@
 
     <game-board [board]="currentBoard" [currentWord]="currentWord" [guessDeadlines]="currentBoard.guessDeadlines" [wordLength]="roundState.wordLength"
                 [currentExpectedGuessCount]="currentBoard.currentExpectedGuessCount" [nextGuessDeadline]="currentBoard.nextGuessDeadline"
-                [guessTimeLimitMs]="currentBoard.guessTimeLimitMs" [maxGuesses]="roundState.maxGuesses"></game-board>
+                [guessTimeLimitMs]="currentBoard.guessTimeLimitMs" [maxGuesses]="roundState.maxGuesses"
+                [avatarPath]="currentPlayer?.avatarPath"></game-board>
 
     <keyboard [currentBoard]="currentBoard" (keyPress)="clickKey($event)"></keyboard>
 
@@ -200,10 +202,11 @@
             <span class="badge alert-info">{{ player.board?.points }}pts</span>
           </h4>
         </div>
-        <game-board [board]="player.board" [wordLength]="roundState.wordLength" 
+        <game-board [board]="player.board" [wordLength]="roundState.wordLength"
                 [currentExpectedGuessCount]="player.board?.currentExpectedGuessCount"
                 [nextGuessDeadline]="player.board?.nextGuessDeadline"
-                [guessTimeLimitMs]="player.board?.guessTimeLimitMs" [maxGuesses]="roundState.maxGuesses"></game-board>
+                [guessTimeLimitMs]="player.board?.guessTimeLimitMs" [maxGuesses]="roundState.maxGuesses"
+                [avatarPath]="player.avatarPath"></game-board>
       </div>
 
     </div>
@@ -223,10 +226,11 @@
           <span class="badge alert-info">{{ player.board?.points }}pts</span>
         </h4>
       </div>
-      <game-board [board]="player.board" [wordLength]="roundState.wordLength" 
+      <game-board [board]="player.board" [wordLength]="roundState.wordLength"
                 [currentExpectedGuessCount]="player.board?.currentExpectedGuessCount"
                 [nextGuessDeadline]="player.board?.nextGuessDeadline"
-                [guessTimeLimitMs]="player.board?.guessTimeLimitMs" [maxGuesses]="roundState.maxGuesses"></game-board>
+                [guessTimeLimitMs]="player.board?.guessTimeLimitMs" [maxGuesses]="roundState.maxGuesses"
+                [avatarPath]="player.avatarPath"></game-board>
     </div>
   </div>
 

--- a/src/Turdle/ClientApp/src/app/services/game.service.ts
+++ b/src/Turdle/ClientApp/src/app/services/game.service.ts
@@ -610,6 +610,7 @@ export interface Player {
   isConnected: boolean;
   rank: number;
   isJointRank: boolean;
+  avatarPath: string | null;
   board: Board | null;
   joinedOn: string;
   registeredAt: string;

--- a/src/Turdle/ClientApp/src/app/tv/tv.component.html
+++ b/src/Turdle/ClientApp/src/app/tv/tv.component.html
@@ -32,7 +32,7 @@
           </h4>
         </div>
 
-        <game-board [board]="player.board" [wordLength]="roundState.wordLength" [maxGuesses]="roundState.maxGuesses"></game-board>
+        <game-board [board]="player.board" [wordLength]="roundState.wordLength" [maxGuesses]="roundState.maxGuesses" [avatarPath]="player.avatarPath"></game-board>
 
       </div>
 


### PR DESCRIPTION
## Summary
- show each player's avatar behind their board
- wire avatarPath through player interface

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6865a588f87c832ab51d8169a0e16ec1