### PR TITLE
Fix home page join form layout

### DIFF
--- a/src/Turdle/ClientApp/src/app/home/home.component.css
+++ b/src/Turdle/ClientApp/src/app/home/home.component.css
@@ -14,5 +14,7 @@
   padding: 1.5rem;
   border-radius: 1.5rem;
   border: 2px solid #33ccff;
-  width: 100%;
+  /* Let bootstrap flex rules size the input so the join button stays
+     on the same line */
+  width: auto;
 }

--- a/src/Turdle/ClientApp/src/app/home/home.component.html
+++ b/src/Turdle/ClientApp/src/app/home/home.component.html
@@ -21,7 +21,7 @@
   <div class="row">
     <div class="col-md-8 offset-md-2">
       <form [formGroup]="joinForm" (ngSubmit)="joinRoom()">
-        <div class="input-group">
+        <div class="input-group flex-nowrap">
           <input type="text" class="form-control massive-input" placeholder="Room code" formControlName="roomCode" required>
           <button class="btn btn-success btn-lg massive-button" type="submit" [disabled]="!joinForm.valid">Join Room</button>
         </div>


### PR DESCRIPTION
## Summary
- tweak `massive-input` style so the join room button no longer wraps

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*
- `npm test --prefix src/Turdle/ClientApp` *(fails: ng not found and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_686bc84f3b70832aa84e6fb396d53bdf