### PR TITLE
Enable response compression

### DIFF
--- a/src/Turdle/Program.cs
+++ b/src/Turdle/Program.cs
@@ -2,6 +2,8 @@ using System.Configuration;
 using System.Text.Json.Serialization;
 using ChatGpt;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.ResponseCompression;
+using System.IO.Compression;
 using Turdle;
 using Turdle.Bots;
 using Turdle.Hubs;
@@ -12,13 +14,19 @@ builder.Logging.AddLog4Net();
 
 // Add services to the container.
 
-builder.Services.AddCors(options => 
-{ 
+builder.Services.AddCors(options =>
+{
     options.AddPolicy("CorsPolicy", p => p
         .WithOrigins("https://localhost:44419")
         .AllowAnyMethod()
         .AllowAnyHeader()
-        .AllowCredentials()); 
+        .AllowCredentials());
+});
+builder.Services.AddResponseCompression(options =>
+{
+    options.EnableForHttps = true;
+    options.Providers.Add<BrotliCompressionProvider>();
+    options.Providers.Add<GzipCompressionProvider>();
 });
 builder.Services.AddControllersWithViews()
     .AddJsonOptions(options =>
@@ -68,6 +76,7 @@ app.UseForwardedHeaders(new ForwardedHeadersOptions
     ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
 });
 app.UseHttpsRedirection();
+app.UseResponseCompression();
 app.UseStaticFiles();
 app.UseRouting();
 app.UseCors("CorsPolicy");

--- a/src/Turdle/Turdle.csproj
+++ b/src/Turdle/Turdle.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- configure Brotli and Gzip response compression
- use response compression middleware before static files
- reference `Microsoft.AspNetCore.ResponseCompression`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686bc8b174a8832aac48290ce0c5ef10