### PR TITLE
Show avatar on admin alias hover

### DIFF
--- a/src/Turdle/ClientApp/src/app/admin/admin.component.css
+++ b/src/Turdle/ClientApp/src/app/admin/admin.component.css
@@ -2,3 +2,24 @@ tr.selected {
   background-color: deeppink;
   color: aqua;
 }
+
+.alias-avatar-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.alias-avatar-preview {
+  display: none;
+  position: absolute;
+  top: 1.5em;
+  left: 0;
+  width: 64px;
+  height: 64px;
+  border: 1px solid #ccc;
+  background-color: white;
+  z-index: 1000;
+}
+
+.alias-avatar-wrapper:hover .alias-avatar-preview {
+  display: block;
+}

--- a/src/Turdle/ClientApp/src/app/admin/admin.component.html
+++ b/src/Turdle/ClientApp/src/app/admin/admin.component.html
@@ -129,7 +129,12 @@
         </tr>
       </thead>
       <tr *ngFor="let player of roundState.players">
-        <th>{{ player.alias }}</th>
+        <th>
+          <span class="alias-avatar-wrapper">
+            {{ player.alias }}
+            <img *ngIf="player.avatarPath" [src]="player.avatarPath" class="alias-avatar-preview" alt="avatar" />
+          </span>
+        </th>
         <td>{{ player.connectionId }}</td>
         <td>{{ player.ready ? '✅' : '' }}</td>
         <td>{{ player.isConnected ? '' : '🔌' }}</td>


### PR DESCRIPTION
## Summary
- add image preview logic for admin alias
- style avatar preview

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
- `npm test --prefix src/Turdle/ClientApp` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871346381c8832a80fb0e9ffb2eafd1