### PR TITLE
Add gameplay instructions on home screen

### DIFF
--- a/src/Turdle/ClientApp/src/app/home/home.component.html
+++ b/src/Turdle/ClientApp/src/app/home/home.component.html
@@ -28,6 +28,27 @@
       </form>
     </div>
   </div>
+
+  <div class="row mt-4">
+    <div class="col-md-8 offset-md-2">
+      <div class="card">
+        <div class="card-body">
+          <h4>How to play</h4>
+          <ul>
+            <li>It’s Turdle with a turbo twist—race to guess faster!</li>
+            <li>Score points by solving quickly and in as few guesses as possible.</li>
+            <li>Invalid words cost you points, so choose wisely.</li>
+            <li><span class="text-success">Green</span> letters are in the right spot.</li>
+            <li><span class="text-warning">Yellow</span> letters are somewhere else in the word.</li>
+            <li><span class="text-muted">Grey</span> letters aren’t in the puzzle at all.</li>
+            <li>Type your guesses or tap them on the virtual keyboard.</li>
+            <li>The keyboard colours show the clues you’ve gathered so far.</li>
+            <li>If you’re stuck, spend points at the bottom to buy a clue.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="container" *ngIf="!isConnected">


### PR DESCRIPTION
## Summary
- show players how to play on the main screen
- use friendlier wording for the list of instructions

## Testing
- `dotnet test --no-build` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_68713420a0f4832aa2b8d8f1e5168658