### PR TITLE
Add bot emoji indicator

### DIFF
--- a/src/Turdle/ClientApp/src/app/admin/admin.component.html
+++ b/src/Turdle/ClientApp/src/app/admin/admin.component.html
@@ -131,7 +131,7 @@
       <tr *ngFor="let player of roundState.players">
         <th>
           <span class="alias-avatar-wrapper">
-            {{ player.alias }}
+            {{ player.alias | botEmoji: player.isBot }}
             <img *ngIf="player.avatarPath" [src]="player.avatarPath" class="alias-avatar-preview" alt="avatar" />
           </span>
         </th>

--- a/src/Turdle/ClientApp/src/app/app.module.ts
+++ b/src/Turdle/ClientApp/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import {AdminService} from "./services/admin.service";
 import {TvComponent} from "./tv/tv.component";
 import {HumanizePipe} from "./humanize.pipe";
+import {BotEmojiPipe} from "./bot-emoji.pipe";
 import {CookieModule} from "ngx-cookie";
 import {FormatMillisecondsPipe} from "./format-milliseconds";
 import TrackByUtils from "./track-by.utils";
@@ -44,6 +45,7 @@ import { GameParamsComponent } from './game-params/game-params.component';
     TvComponent,
     PointScheduleComponent,
     GameParamsComponent,
+    BotEmojiPipe,
     NotAliasPipe,
     ToastsContainer
   ],

--- a/src/Turdle/ClientApp/src/app/bot-emoji.pipe.ts
+++ b/src/Turdle/ClientApp/src/app/bot-emoji.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'botEmoji'
+})
+export class BotEmojiPipe implements PipeTransform {
+  transform(alias: string, isBot: boolean | null | undefined): string {
+    return isBot ? `${alias} 🤖` : alias;
+  }
+}

--- a/src/Turdle/ClientApp/src/app/game/game.component.html
+++ b/src/Turdle/ClientApp/src/app/game/game.component.html
@@ -12,9 +12,9 @@
       <table class='table' aria-labelledby="tableLabel">
         <tbody>
         <tr *ngFor="let player of roundState.players; trackBy: trackByUtils.trackByPlayer">
-          <td *ngIf="player.alias != currentPlayer?.alias">{{ player.alias }}</td>
+          <td *ngIf="player.alias != currentPlayer?.alias">{{ player.alias | botEmoji: player.isBot }}</td>
           <th *ngIf="player.alias == currentPlayer?.alias">
-            {{ player.alias }}
+            {{ player.alias | botEmoji: player.isBot }}
             <button class="btn btn-sm btn-outline-info" (click)="logOut()">Change</button>
           </th>
           <td>{{ player.ready ? '✅' : '' }}</td>
@@ -72,7 +72,7 @@
           <table class="table table-hover">
             <tbody>
               <tr *ngFor="let chatMessage of chatMessages" (click)="prepopulateChat(chatMessage.alias)" class="clickable">
-                <th class="text-nowrap">{{ chatMessage.alias }}</th>
+                <th class="text-nowrap">{{ chatMessage.alias | botEmoji: (roundState.players.find(p => p.alias == chatMessage.alias)?.isBot) }}</th>
                 <td>{{ chatMessage.message }}</td>
               </tr>
             </tbody>
@@ -114,7 +114,7 @@
               {{ player.board?.isJointRank ? '=' : '' }}{{ player.board?.rank }}<sup>{{ player.board?.rank | ordinal }}</sup>
             </span>
           </h4>
-          <h4>{{ player.alias }}{{ player.isConnected ? '' : '🔌' }}</h4>
+          <h4>{{ player.alias | botEmoji: player.isBot }}{{ player.isConnected ? '' : '🔌' }}</h4>
           <h4>
             <span class="badge alert-info">{{ player.board?.points }}pts</span>
           </h4>
@@ -142,7 +142,7 @@
               {{ currentPlayer?.board?.isJointRank ? '=' : '' }}{{ currentPlayer?.board?.rank }}<sup>{{ currentPlayer?.board?.rank | ordinal:false }}</sup>
             </span>
           </h3>
-          <h3 *ngIf="roundState.status != 'Finished'">Go {{ currentPlayer?.alias }}!</h3>
+          <h3 *ngIf="roundState.status != 'Finished'">Go {{ currentPlayer?.alias | botEmoji: currentPlayer?.isBot }}!</h3>
           <!-- TODO Limit this to admin only-->
           <h3 *ngIf="roundState.status == 'Finished'"><a class="btn btn-outline-success btn-lg" (click)="startGame()">Start Round</a></h3>
           <h3>
@@ -197,7 +197,7 @@
               {{ player.board?.isJointRank ? '=' : '' }}{{ player.board?.rank }}<sup>{{ player.board?.rank | ordinal:false }}</sup>
             </span>
           </h4>
-          <h4>{{ player.alias }}{{ player.isConnected ? '' : '🔌' }}</h4>
+          <h4>{{ player.alias | botEmoji: player.isBot }}{{ player.isConnected ? '' : '🔌' }}</h4>
           <h4>
             <span class="badge alert-info">{{ player.board?.points }}pts</span>
           </h4>
@@ -221,7 +221,7 @@
               {{ player.board?.isJointRank ? '=' : '' }}{{ player.board?.rank }}<sup>{{ player.board?.rank | ordinal:false }}</sup>
             </span>
         </h4>
-        <h4>{{ player.alias }}{{ player.isConnected ? '' : '🔌' }}</h4>
+        <h4>{{ player.alias | botEmoji: player.isBot }}{{ player.isConnected ? '' : '🔌' }}</h4>
         <h4>
           <span class="badge alert-info">{{ player.board?.points }}pts</span>
         </h4>
@@ -259,7 +259,7 @@
                 {{ player.isJointRank ? '=' : '' }}{{ player.rank }}<sup>{{ player.rank | ordinal:false }}</sup>
               </span>
             </td>
-            <th>{{ player.alias }}</th>
+            <th>{{ player.alias | botEmoji: player.isBot }}</th>
             <th>{{ player.points }}</th>
             <th>{{ player.board?.points | showPlus }}</th>
           </tr>

--- a/src/Turdle/ClientApp/src/app/game/game.component.ts
+++ b/src/Turdle/ClientApp/src/app/game/game.component.ts
@@ -227,7 +227,10 @@ export class GameComponent {
     return this.gameService.chatMessages;
   }
   get typingPlayers(): string[] {
-    return this.gameService.typingAliases;
+    return this.gameService.typingAliases.map(alias => {
+      const isBot = this.roundState.players.find(p => p.alias === alias)?.isBot;
+      return isBot ? `${alias} 🤖` : alias;
+    });
   }
 
   // UTILS

--- a/src/Turdle/ClientApp/src/app/tv/tv.component.html
+++ b/src/Turdle/ClientApp/src/app/tv/tv.component.html
@@ -5,7 +5,7 @@
       <table class='table table' aria-labelledby="tableLabel">
         <tbody>
         <tr *ngFor="let player of roundState.players; trackBy: trackByUtils.trackByPlayer">
-          <td>{{ player.alias }}</td>
+          <td>{{ player.alias | botEmoji: player.isBot }}</td>
           <td>{{ player.ready ? '✅' : '' }}</td>
           <td>{{ player.isConnected ? '' : '🔌' }}</td>
         </tr>
@@ -26,7 +26,7 @@
               {{ player.board?.isJointRank ? '=' : '' }}{{ player.board?.rank }}<sup>{{ player.board?.rank | ordinal }}</sup>
             </span>
           </h4>
-          <h4>{{ player.alias }}{{ player.isConnected ? '' : '🔌' }}</h4>
+          <h4>{{ player.alias | botEmoji: player.isBot }}{{ player.isConnected ? '' : '🔌' }}</h4>
           <h4>
             <span class="badge alert-info">{{ player.board?.points }}pts</span>
           </h4>
@@ -55,7 +55,7 @@
               {{ player.isJointRank ? '=' : '' }}{{ player.rank }}<sup>{{ player.rank | ordinal:false }}</sup>
             </span>
             </td>
-            <th>{{ player.alias }}</th>
+            <th>{{ player.alias | botEmoji: player.isBot }}</th>
             <th>{{ player.points }}</th>
             <th>{{ player.board?.points | showPlus }}</th>
           </tr>


### PR DESCRIPTION
## Summary
- show bot emoji next to bot player names
- add `BotEmojiPipe` for Angular templates
- display emoji in chat and typing indicators

## Testing
- `npm test` *(fails: `ng` not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68715a6b8490832a8b9fe1ecbe723140