### PR TITLE
Improve how-to colors

### DIFF
--- a/src/Turdle/ClientApp/src/app/home/home.component.css
+++ b/src/Turdle/ClientApp/src/app/home/home.component.css
@@ -38,3 +38,12 @@
   font-size: 5rem;
   text-shadow: 2px 2px #33ccff;
 }
+
+.howto-tile {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  margin-right: 0.1rem;
+  font-weight: bold;
+  border: 1px solid black;
+  text-align: center;
+}

--- a/src/Turdle/ClientApp/src/app/home/home.component.html
+++ b/src/Turdle/ClientApp/src/app/home/home.component.html
@@ -38,9 +38,9 @@
             <li>Wordle with a turbo twist — race to solve fastest!</li>
             <li>Score points by solving quickly and in as few guesses as possible.</li>
             <li>Invalid words cost you points, so choose wisely.</li>
-            <li><span class="text-success">Green</span> letters are in the right spot.</li>
-            <li><span class="text-warning">Yellow</span> letters are somewhere else in the word.</li>
-            <li><span class="text-muted">Grey</span> letters aren’t in the puzzle at all.</li>
+            <li><span class="howto-tile letter-color" data-status="Correct">Green</span> letters are in the right spot.</li>
+            <li><span class="howto-tile letter-color" data-status="Present">Yellow</span> letters are somewhere else in the word.</li>
+            <li><span class="howto-tile letter-color" data-status="Absent">Grey</span> letters aren’t in the puzzle at all.</li>
             <li>Type your guesses or tap them on the virtual keyboard.</li>
             <li>The keyboard colours show the clues you’ve gathered so far.</li>
             <li>If you’re stuck, spend points at the bottom to buy a clue.</li>

--- a/src/Turdle/ClientApp/src/app/home/home.component.ts
+++ b/src/Turdle/ClientApp/src/app/home/home.component.ts
@@ -7,7 +7,7 @@ import { HomeService } from '../services/home.service';
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.css']
+  styleUrls: ['./home.component.css', '../letter-colors.shared.css']
 })
 export class HomeComponent {
 


### PR DESCRIPTION
## Summary
- show Wordle clue colors as square tiles in the How to Play list
- include shared letter color stylesheet in home component

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68715bfb8228832a83dac8516ff4a050