### PR TITLE
Fix bot emoji pipe alias typing

### DIFF
--- a/src/Turdle/ClientApp/src/app/bot-emoji.pipe.ts
+++ b/src/Turdle/ClientApp/src/app/bot-emoji.pipe.ts
@@ -4,7 +4,11 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'botEmoji'
 })
 export class BotEmojiPipe implements PipeTransform {
-  transform(alias: string, isBot: boolean | null | undefined): string {
+  transform(alias: string | null | undefined, isBot: boolean | null | undefined): string {
+    if (!alias) {
+      return '';
+    }
+
     return isBot ? `${alias} 🤖` : alias;
   }
 }


### PR DESCRIPTION
## Summary
- adjust `BotEmojiPipe` to accept `string | null | undefined`

## Testing
- `dotnet test src/Turdle.sln` *(fails: command not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871887813f8832a878aedc608ce3e4f