### PR TITLE
Improve tile styling in instructions

### DIFF
--- a/src/Turdle/ClientApp/src/app/home/home.component.css
+++ b/src/Turdle/ClientApp/src/app/home/home.component.css
@@ -41,7 +41,9 @@
 
 .howto-tile {
   display: inline-block;
-  padding: 0.25rem 0.5rem;
+  width: 2rem;
+  height: 2rem;
+  line-height: 2rem;
   margin-right: 0.1rem;
   font-weight: bold;
   border: 1px solid black;

--- a/src/Turdle/ClientApp/src/app/home/home.component.css
+++ b/src/Turdle/ClientApp/src/app/home/home.component.css
@@ -44,8 +44,8 @@
   width: 2rem;
   height: 2rem;
   line-height: 2rem;
-  margin-right: 0.1rem;
+  margin-right: 0;
   font-weight: bold;
-  border: 1px solid black;
+  border: 1px solid #fff;
   text-align: center;
 }

--- a/src/Turdle/ClientApp/src/app/home/home.component.html
+++ b/src/Turdle/ClientApp/src/app/home/home.component.html
@@ -38,9 +38,30 @@
             <li>Wordle with a turbo twist — race to solve fastest!</li>
             <li>Score points by solving quickly and in as few guesses as possible.</li>
             <li>Invalid words cost you points, so choose wisely.</li>
-            <li><span class="howto-tile letter-color" data-status="Correct">Green</span> letters are in the right spot.</li>
-            <li><span class="howto-tile letter-color" data-status="Present">Yellow</span> letters are somewhere else in the word.</li>
-            <li><span class="howto-tile letter-color" data-status="Absent">Grey</span> letters aren’t in the puzzle at all.</li>
+            <li>
+              <span class="howto-tile letter-color" data-status="Correct">G</span>
+              <span class="howto-tile letter-color" data-status="Correct">R</span>
+              <span class="howto-tile letter-color" data-status="Correct">E</span>
+              <span class="howto-tile letter-color" data-status="Correct">E</span>
+              <span class="howto-tile letter-color" data-status="Correct">N</span>
+              letters are in the right spot.
+            </li>
+            <li>
+              <span class="howto-tile letter-color" data-status="Present">Y</span>
+              <span class="howto-tile letter-color" data-status="Present">E</span>
+              <span class="howto-tile letter-color" data-status="Present">L</span>
+              <span class="howto-tile letter-color" data-status="Present">L</span>
+              <span class="howto-tile letter-color" data-status="Present">O</span>
+              <span class="howto-tile letter-color" data-status="Present">W</span>
+              letters are somewhere else in the word.
+            </li>
+            <li>
+              <span class="howto-tile letter-color" data-status="Absent">G</span>
+              <span class="howto-tile letter-color" data-status="Absent">R</span>
+              <span class="howto-tile letter-color" data-status="Absent">E</span>
+              <span class="howto-tile letter-color" data-status="Absent">Y</span>
+              letters aren’t in the puzzle at all.
+            </li>
             <li>Type your guesses or tap them on the virtual keyboard.</li>
             <li>The keyboard colours show the clues you’ve gathered so far.</li>
             <li>If you’re stuck, spend points at the bottom to buy a clue.</li>

--- a/src/Turdle/ClientApp/src/app/home/home.component.html
+++ b/src/Turdle/ClientApp/src/app/home/home.component.html
@@ -39,27 +39,15 @@
             <li>Score points by solving quickly and in as few guesses as possible.</li>
             <li>Invalid words cost you points, so choose wisely.</li>
             <li>
-              <span class="howto-tile letter-color" data-status="Correct">G</span>
-              <span class="howto-tile letter-color" data-status="Correct">R</span>
-              <span class="howto-tile letter-color" data-status="Correct">E</span>
-              <span class="howto-tile letter-color" data-status="Correct">E</span>
-              <span class="howto-tile letter-color" data-status="Correct">N</span>
+              <span class="howto-tile letter-color" data-status="Correct">G</span><span class="howto-tile letter-color" data-status="Correct">R</span><span class="howto-tile letter-color" data-status="Correct">E</span><span class="howto-tile letter-color" data-status="Correct">E</span><span class="howto-tile letter-color" data-status="Correct">N</span>
               letters are in the right spot.
             </li>
             <li>
-              <span class="howto-tile letter-color" data-status="Present">Y</span>
-              <span class="howto-tile letter-color" data-status="Present">E</span>
-              <span class="howto-tile letter-color" data-status="Present">L</span>
-              <span class="howto-tile letter-color" data-status="Present">L</span>
-              <span class="howto-tile letter-color" data-status="Present">O</span>
-              <span class="howto-tile letter-color" data-status="Present">W</span>
+              <span class="howto-tile letter-color" data-status="Present">Y</span><span class="howto-tile letter-color" data-status="Present">E</span><span class="howto-tile letter-color" data-status="Present">L</span><span class="howto-tile letter-color" data-status="Present">L</span><span class="howto-tile letter-color" data-status="Present">O</span><span class="howto-tile letter-color" data-status="Present">W</span>
               letters are somewhere else in the word.
             </li>
             <li>
-              <span class="howto-tile letter-color" data-status="Absent">G</span>
-              <span class="howto-tile letter-color" data-status="Absent">R</span>
-              <span class="howto-tile letter-color" data-status="Absent">E</span>
-              <span class="howto-tile letter-color" data-status="Absent">Y</span>
+              <span class="howto-tile letter-color" data-status="Absent">G</span><span class="howto-tile letter-color" data-status="Absent">R</span><span class="howto-tile letter-color" data-status="Absent">E</span><span class="howto-tile letter-color" data-status="Absent">Y</span>
               letters aren’t in the puzzle at all.
             </li>
             <li>Type your guesses or tap them on the virtual keyboard.</li>


### PR DESCRIPTION
## Summary
- update instructions to show individual tiles spelling GREEN, YELLOW, and GREY
- size example tiles to match board tile appearance

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6873bb9ee0c8832a9f21967edb72a650