### PR TITLE
Add room images

### DIFF
--- a/src/ChatGpt/RoomAvatarService.cs
+++ b/src/ChatGpt/RoomAvatarService.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging;
+
+namespace ChatGpt
+{
+    public class RoomAvatarService
+    {
+        private readonly ImageGenerationClient _imageClient;
+        private readonly ILogger<RoomAvatarService> _logger;
+        private readonly string _cacheDir;
+        private readonly HttpClient _httpClient = new();
+
+        public RoomAvatarService(ImageGenerationClient imageClient, ILogger<RoomAvatarService> logger, string? cacheDirectory = null)
+        {
+            _imageClient = imageClient;
+            _logger = logger;
+            _cacheDir = cacheDirectory ?? Path.Combine(AppContext.BaseDirectory, "wwwroot", "room-images");
+            Directory.CreateDirectory(_cacheDir);
+        }
+
+        public async Task<string?> GetOrGenerateImage(string description)
+        {
+            if (string.IsNullOrWhiteSpace(description))
+                throw new ArgumentException("Description must be provided", nameof(description));
+
+            var fileName = SanitizeFileName(description) + ".png";
+            var filePath = Path.Combine(_cacheDir, fileName);
+            var relativePath = Path.Combine("room-images", fileName);
+            if (File.Exists(filePath))
+            {
+                _logger.LogInformation("Returning cached room image for {description}", description);
+                return relativePath;
+            }
+
+            var prompt = $"Cartoon of a {description}";
+            var imageUrl = await _imageClient.GenerateImage(prompt, ImageSize.DallE2Small);
+
+            if (string.IsNullOrEmpty(imageUrl))
+            {
+                _logger.LogWarning("Image generation returned no URL for {description}", description);
+                return null;
+            }
+
+            try
+            {
+                var bytes = await _httpClient.GetByteArrayAsync(imageUrl);
+                await File.WriteAllBytesAsync(filePath, bytes);
+                _logger.LogInformation("Cached room image for {description} at {path}", description, filePath);
+                return relativePath;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to cache room image for {description}", description);
+                return null;
+            }
+        }
+
+        private static string SanitizeFileName(string name)
+        {
+            var invalid = Path.GetInvalidFileNameChars();
+            var valid = new string(name.ToLower().Select(c => invalid.Contains(c) ? '_' : c).ToArray());
+            return valid.Replace(' ', '_');
+        }
+    }
+}

--- a/src/Turdle/ClientApp/src/app/game/game.component.html
+++ b/src/Turdle/ClientApp/src/app/game/game.component.html
@@ -5,6 +5,7 @@
 
     <div class="col-md-3">
       <h2 class="room-code">
+        <img *ngIf="roomImagePath" [src]="roomImagePath" width="32" height="32" class="me-1" />
         {{ roomCode }}
         <span (click)="copyUrl()">🔗</span>
       </h2>

--- a/src/Turdle/ClientApp/src/app/game/game.component.ts
+++ b/src/Turdle/ClientApp/src/app/game/game.component.ts
@@ -208,6 +208,9 @@ export class GameComponent {
   get currentBoard(): Board | null {
     return this.gameService.currentBoard;
   }
+  get roomImagePath(): string | null {
+    return this.gameService.roomImagePath;
+  }
   get currentWord(): string {
     return this.gameService.currentWord;
   }

--- a/src/Turdle/ClientApp/src/app/services/game.service.ts
+++ b/src/Turdle/ClientApp/src/app/services/game.service.ts
@@ -9,6 +9,7 @@ import {CookieService} from "ngx-cookie";
 })
 export class GameService {
   public roomCode: string = '';
+  public roomImagePath: string | null = null;
 
   public playerAlias: string = '';
   public pointSchedule: PointSchedule | null = null;
@@ -150,6 +151,12 @@ export class GameService {
     this.http.get<GameParameters>(this.baseUrl + 'getgameparameters', { params: new HttpParams().set('roomCode', this.roomCode) })
       .subscribe(async result => {
         this.gameParams = result;
+      }, error => console.error(error));
+
+    this.http.get<Room[]>(this.baseUrl + 'getrooms')
+      .subscribe(result => {
+        const room = result.find(r => r.roomCode === this.roomCode);
+        this.roomImagePath = room ? room.imagePath : null;
       }, error => console.error(error));
 
     this.http.get<ChatMessage[]>(this.baseUrl + 'getchatmessages', { params: new HttpParams().set('roomCode', this.roomCode) })
@@ -696,6 +703,7 @@ export interface PointSchedule {
 export interface Room {
   createdOn: Date;
   roomCode: string;
+  imagePath: string | null;
   players: Player[];
   adminAlias: string;
   roundNumber: number;

--- a/src/Turdle/Program.cs
+++ b/src/Turdle/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddSingleton<WordService>();
 builder.Services.AddSingleton<ChatGptClient>();
 builder.Services.AddSingleton<ImageGenerationClient>();
 builder.Services.AddSingleton<PersonalityAvatarService>();
+builder.Services.AddSingleton<RoomAvatarService>();
 builder.Services.AddSingleton<BotFactory>();
 builder.Services.AddSingleton<IPointService, PointService>();
 builder.Services.AddSingleton<IWordAnalysisService, WordAnalysisService>();

--- a/src/Turdle/RoomManager.cs
+++ b/src/Turdle/RoomManager.cs
@@ -27,6 +27,7 @@ public class RoomManager
     private readonly IWordAnalysisService _wordAnalyst;
     private readonly BotFactory _botFactory;
     private readonly PersonalityAvatarService _avatarService;
+    private readonly RoomAvatarService _roomAvatarService;
 
     private readonly Board _fakeReadyBoard;
     
@@ -36,7 +37,8 @@ public class RoomManager
     private readonly ConcurrentDictionary<string, Room> _rooms = new ConcurrentDictionary<string, Room>();
 
     public RoomManager(ILogger<RoomManager> logger, IHubContext<GameHub> gameHubContext, IHubContext<AdminHub> adminHubContext, IHubContext<HomeHub> homeHubContext,
-        WordService wordService, IPointService pointService, IWordAnalysisService wordAnalyst, BotFactory botFactory, PersonalityAvatarService avatarService)
+        WordService wordService, IPointService pointService, IWordAnalysisService wordAnalyst, BotFactory botFactory, PersonalityAvatarService avatarService,
+        RoomAvatarService roomAvatarService)
     {
         _logger = logger;
         _gameHubContext = gameHubContext;
@@ -47,6 +49,7 @@ public class RoomManager
         _homeHubContext = homeHubContext;
         _botFactory = botFactory;
         _avatarService = avatarService;
+        _roomAvatarService = roomAvatarService;
 
         var assembly = Assembly.GetExecutingAssembly();
         using (var stream = assembly.GetManifestResourceStream("Turdle.Resources.Adjectives.txt"))
@@ -76,7 +79,7 @@ public class RoomManager
         }
 
         var room = new Room(_gameHubContext, _adminHubContext, _wordService, _pointService, _logger, _wordAnalyst,
-            roomCode, BroadcastRooms, _botFactory, _avatarService);
+            roomCode, BroadcastRooms, _botFactory, _avatarService, _roomAvatarService);
         _rooms.TryAdd(roomCode, room);
 
         await BroadcastRooms();

--- a/src/Turdle/ViewModel/RoomSummary.cs
+++ b/src/Turdle/ViewModel/RoomSummary.cs
@@ -5,6 +5,8 @@ namespace Turdle.ViewModel;
 public class RoomSummary
 {
     public string RoomCode { get; set; }
+
+    public string? ImagePath { get; set; }
     
     public MaskedPlayer[] Players { get; set; }
     


### PR DESCRIPTION
## Summary
- support caching room animal/adjective images
- inject `RoomAvatarService` and update DI
- broadcast image path via `RoomSummary`
- fetch and display room images in the UI

## Testing
- `dotnet test --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6865a9729e60832a96c6f990a56273f0