### PR TITLE
Update room init and header info

### DIFF
--- a/src/Turdle/ClientApp/proxy.conf.js
+++ b/src/Turdle/ClientApp/proxy.conf.js
@@ -9,6 +9,7 @@ const PROXY_CONFIG = [
       "/getgamestate",
       "/getgameparameters",
       "/getrooms",
+      "/getroom",
       "/getpreviousalias",
       "/getpointschedule",
       "/getchatmessages",

--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.css
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.css
@@ -43,3 +43,7 @@ html {
   top: 50%;
   transform: translateY(-50%);
 }
+
+.room-header-info {
+  margin-left: 1rem;
+}

--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.html
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.html
@@ -40,6 +40,10 @@
             </a>
           </li>
         </ul>
+        <div class="d-flex align-items-center room-header-info" *ngIf="roomCode">
+          <img *ngIf="roomImagePath" [src]="roomImagePath" width="32" height="32" class="me-1" />
+          <span class="fw-bold">{{ roomCode }}</span>
+        </div>
       </div>
     </div>
   </nav>

--- a/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.ts
+++ b/src/Turdle/ClientApp/src/app/nav-menu/nav-menu.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { EnvironmentService } from '../services/environment.service';
+import { GameService } from '../services/game.service';
 
 @Component({
   selector: 'app-nav-menu',
@@ -13,7 +14,7 @@ export class NavMenuComponent implements OnInit {
   public environmentName: string | null = null;
   public environmentVersion: string | null = null;
 
-  constructor(private environmentService: EnvironmentService) {
+  constructor(private environmentService: EnvironmentService, private gameService: GameService) {
   }
 
   ngOnInit(): void {
@@ -28,5 +29,13 @@ export class NavMenuComponent implements OnInit {
 
   toggle() {
     this.isExpanded = !this.isExpanded;
+  }
+
+  get roomCode(): string {
+    return this.gameService.roomCode;
+  }
+
+  get roomImagePath(): string | null {
+    return this.gameService.roomImagePath;
   }
 }

--- a/src/Turdle/ClientApp/src/app/services/game.service.ts
+++ b/src/Turdle/ClientApp/src/app/services/game.service.ts
@@ -153,10 +153,9 @@ export class GameService {
         this.gameParams = result;
       }, error => console.error(error));
 
-    this.http.get<Room[]>(this.baseUrl + 'getrooms')
+    this.http.get<Room>(this.baseUrl + 'getroom', { params: new HttpParams().set('roomCode', this.roomCode) })
       .subscribe(result => {
-        const room = result.find(r => r.roomCode === this.roomCode);
-        this.roomImagePath = room ? room.imagePath : null;
+        this.roomImagePath = result.imagePath;
       }, error => console.error(error));
 
     this.http.get<ChatMessage[]>(this.baseUrl + 'getchatmessages', { params: new HttpParams().set('roomCode', this.roomCode) })

--- a/src/Turdle/Controllers/GameController.cs
+++ b/src/Turdle/Controllers/GameController.cs
@@ -28,6 +28,16 @@ public class GameController : ControllerBase
     }
 
     [HttpGet]
+    [Route("GetRoom")]
+    public Task<RoomSummary> GetRoom(string roomCode)
+    {
+        using (LogContext.Create(_logger, "API", "GetRoom"))
+        {
+            return Task.FromResult(_roomManager.GetRoom(roomCode).ToSummary());
+        }
+    }
+
+    [HttpGet]
     [Route("GetGameState")]
     public Task<IRoundState<IPlayer<IBoard<IRow<ITile>, ITile>, IRow<ITile>, ITile>, IBoard<IRow<ITile>, ITile>, IRow<ITile>, ITile>> GetGameState(string roomCode)
     {

--- a/src/Turdle/Room.cs
+++ b/src/Turdle/Room.cs
@@ -87,23 +87,23 @@ public class Room
         _botFactory = botFactory;
         _avatarService = avatarService;
         _roomAvatarService = roomAvatarService;
+    }
 
-        Task.Run(async () =>
+    public async Task Init()
+    {
+        try
         {
-            try
+            var path = await _roomAvatarService.GetOrGenerateImage(_roomCode);
+            if (path != null)
             {
-                var path = await _roomAvatarService.GetOrGenerateImage(roomCode);
-                if (path != null)
-                {
-                    ImagePath = path;
-                    await _roomSummaryUpdatedCallback();
-                }
+                ImagePath = path;
+                await _roomSummaryUpdatedCallback();
             }
-            catch (Exception e)
-            {
-                _logger.LogError(e, $"Error generating room image for {roomCode}");
-            }
-        });
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, $"Error generating room image for {_roomCode}");
+        }
     }
 
     public RoomSummary ToSummary()

--- a/src/Turdle/RoomManager.cs
+++ b/src/Turdle/RoomManager.cs
@@ -82,6 +82,7 @@ public class RoomManager
             roomCode, BroadcastRooms, _botFactory, _avatarService, _roomAvatarService);
         _rooms.TryAdd(roomCode, room);
 
+        await room.Init();
         await BroadcastRooms();
         return roomCode;
     }


### PR DESCRIPTION
## Summary
- move room image generation into Init method and call from RoomManager
- allow fetching a single room summary via `GetRoom` API
- query new API from GameService
- display room name and image in the header on game page
- proxy config updated for new endpoint

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6874f64bad64832a98ab0fffae74664e